### PR TITLE
Add single producer implementation

### DIFF
--- a/pkg/shortener/generator.go
+++ b/pkg/shortener/generator.go
@@ -74,3 +74,15 @@ func generateFriendlyID() string {
 	number := rng.Intn(100) // 0–99
 	return fmt.Sprintf("%s-%s-%02d", adj, animal, number)
 }
+
+func generateAndAdd(m map[string]string, longURL string) (string, error) {
+	// NOTE: a better check for saturation is the count of active URLs vs the generateFriendlyID probability space
+	for retries := 5; retries > 0; retries -= 1 {
+		short := generateFriendlyID()
+		if _, found := m[short]; !found {
+			m[short] = longURL
+			return short, nil
+		}
+	}
+	return "", fmt.Errorf("memory is too saturated")
+}

--- a/pkg/shortener/singleproducer.go
+++ b/pkg/shortener/singleproducer.go
@@ -1,0 +1,78 @@
+package shortener
+
+import (
+	"fmt"
+	"sync"
+)
+
+type SingleProducerShortener struct {
+	urls     map[string]string
+	requests chan *request
+}
+
+func NewSingleProducerShortener() UrlShortener {
+	s := &SingleProducerShortener{
+		urls:     map[string]string{},
+		requests: make(chan *request),
+	}
+	go s.startProducer()
+	return s
+}
+
+type request struct {
+	s  slot
+	wg sync.WaitGroup
+}
+
+type slot struct {
+	key, val string
+	err      error
+}
+
+func (s *SingleProducerShortener) startProducer() {
+	for r := range s.requests {
+		s.handleRequest(r)
+	}
+}
+
+func (s *SingleProducerShortener) handleRequest(r *request) {
+	defer r.wg.Done()
+
+	// NOTE: a better check for saturation is the count of active URLs vs the generateFriendlyID probability space
+	for retries := 5; retries > 0; retries -= 1 {
+		short := generateFriendlyID()
+		if _, found := s.urls[short]; !found {
+			s.urls[short] = r.s.key
+			r.s.val = short
+			return
+		}
+	}
+
+	r.s.err = fmt.Errorf("memory is too saturated")
+	return
+}
+
+// validate we've implemented the UrlShortener interface
+var _ UrlShortener = (*SingleProducerShortener)(nil)
+
+// Shorten implements UrlShortener.
+func (s *SingleProducerShortener) Shorten(url string) (string, error) {
+	r := &request{
+		s: slot{
+			key: url,
+		},
+		wg: sync.WaitGroup{},
+	}
+	r.wg.Add(1)
+	s.requests <- r
+	r.wg.Wait()
+	return r.s.val, r.s.err
+}
+
+// Expand implements UrlShortener.
+func (s *SingleProducerShortener) Expand(shortenedUrl string) (string, error) {
+	if dest, found := s.urls[shortenedUrl]; found {
+		return dest, nil
+	}
+	return "", fmt.Errorf("short URL not found")
+}

--- a/pkg/shortener/singlethreaded.go
+++ b/pkg/shortener/singlethreaded.go
@@ -22,17 +22,7 @@ func NewSingleThreadedShortener() UrlShortener {
 func (s *SingleThreadedShortener) Shorten(longURL string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-
-	// NOTE: a better check for saturation is the count of active URLs vs the generateFriendlyID probability space
-	for retries := 5; retries > 0; retries -= 1 {
-		short := generateFriendlyID()
-		if _, found := s.urls[short]; !found {
-			s.urls[short] = longURL
-			return short, nil
-		}
-	}
-
-	return "", fmt.Errorf("memory is too saturated")
+	return generateAndAdd(s.urls, longURL)
 }
 
 func (s *SingleThreadedShortener) Expand(shortURL string) (string, error) {

--- a/pkg/shortener/singlethreaded.go
+++ b/pkg/shortener/singlethreaded.go
@@ -13,7 +13,7 @@ type SingleThreadedShortener struct {
 // validate we've implemented the UrlShortener interface
 var _ UrlShortener = (*SingleThreadedShortener)(nil)
 
-func NewSingleThreadedShortener() *SingleThreadedShortener {
+func NewSingleThreadedShortener() UrlShortener {
 	return &SingleThreadedShortener{
 		urls: make(map[string]string),
 	}


### PR DESCRIPTION
Adds a single producer implementation that creates a producer thread that handles all write requests. Read requests are not locked.

Also adds an implementation chooser for handling requests.